### PR TITLE
Fix README heading placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# ado-dad
+
+olx clone
+
 <p align="center">
   <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
 </p>
@@ -97,5 +101,3 @@ Nest is an MIT-licensed open source project. It can grow thanks to the sponsors 
 ## License
 
 Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).
-# ado-dad
-olx clone 


### PR DESCRIPTION
## Summary
- move project heading and tagline to the top of the README
- remove leftover lines after the license section

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661f621db48323ba67a43c8f12bb2b